### PR TITLE
PSEC-1472 increase test stage timout for the standard s3 module

### DIFF
--- a/modules/terraform_module_pipeline/build.tf
+++ b/modules/terraform_module_pipeline/build.tf
@@ -3,7 +3,7 @@ module "build_artifact_step" {
 
   docker_required    = true
   step_name          = "${module.common.pipeline_name}-build"
-  timeout_in_minutes = 15
+  timeout_in_minutes = var.test_timeout_in_minutes
 
   s3_bucket_arn                    = module.common.bucket_arn
   vpc_config                       = var.vpc_config

--- a/modules/terraform_module_pipeline/variables.tf
+++ b/modules/terraform_module_pipeline/variables.tf
@@ -62,3 +62,7 @@ variable "sns_topic_arn" {
   type = string
   default = null
 }
+
+variable "test_timeout_in_minutes" {
+  default = 15
+}

--- a/pipelines.tf
+++ b/pipelines.tf
@@ -166,6 +166,8 @@ module "tf-s3-bucket-standard" {
   src_repo      = "terraform-aws-s3-bucket-standard"
   branch        = "main"
 
+  test_timeout_in_minutes = 25
+
   accounts                    = local.accounts
   vpc_config                  = local.vpc_config
   ci_agent_to_internet_sg_id  = local.ci_agent_to_internet_sg_id


### PR DESCRIPTION
currently the terratest timout has been increased to 20m in the
buildspec of the repo. This adds some overhead for the docker build
