### PR TITLE
PSEC-1603: Replace 3rd party terraform modules with fork repo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,6 @@ locals {
 
 module "label" {
   source  = "git@github.com:hmrc/terraform-null-label.git"
-  version = "0.24.1"
 
   namespace = "mdtp"
   stage     = terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 module "label" {
-  source  = "cloudposse/label/null"
+  source  = "git@github.com:hmrc/terraform-null-label.git"
   version = "0.24.1"
 
   namespace = "mdtp"

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 module "label" {
-  source = "git@github.com:hmrc/terraform-null-label.git?ref=v0.24.1"
+  source = "github.com/hmrc/terraform-null-label?ref=0.24.1"
 
   namespace = "mdtp"
   stage     = terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 module "label" {
-  source  = "git@github.com:hmrc/terraform-null-label.git?ref=v0.24.1"
+  source = "git@github.com:hmrc/terraform-null-label.git?ref=v0.24.1"
 
   namespace = "mdtp"
   stage     = terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 module "label" {
-  source  = "git@github.com:hmrc/terraform-null-label.git"
+  source  = "git@github.com:hmrc/terraform-null-label.git?ref=v0.24.1"
 
   namespace = "mdtp"
   stage     = terraform.workspace

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ locals {
 }
 
 module "label" {
-  source = "github.com/hmrc/terraform-null-label?ref=0.24.1"
+  source = "github.com/hmrc/terraform-null-label?ref=0.25.0"
 
   namespace = "mdtp"
   stage     = terraform.workspace

--- a/modules/networking/vpc.tf
+++ b/modules/networking/vpc.tf
@@ -4,7 +4,7 @@ module "vpc" {
     aws = aws.no-default-tags
   }
 
-  source  = "git@github.com:hmrc/terraform-aws-vpc.git?ref=v3.6.0"
+  source = "git@github.com:hmrc/terraform-aws-vpc.git?ref=v3.6.0"
 
   name = var.name_prefix
 

--- a/modules/networking/vpc.tf
+++ b/modules/networking/vpc.tf
@@ -4,7 +4,7 @@ module "vpc" {
     aws = aws.no-default-tags
   }
 
-  source  = "git@github.com:hmrc/terraform-aws-vpc.git"
+  source  = "git@github.com:hmrc/terraform-aws-vpc.git?ref=v3.6.0"
 
   name = var.name_prefix
 

--- a/modules/networking/vpc.tf
+++ b/modules/networking/vpc.tf
@@ -4,7 +4,7 @@ module "vpc" {
     aws = aws.no-default-tags
   }
 
-  source  = "terraform-aws-modules/vpc/aws"
+  source  = "git@github.com:hmrc/terraform-aws-vpc.git"
   version = "3.6.0"
 
   name = var.name_prefix

--- a/modules/networking/vpc.tf
+++ b/modules/networking/vpc.tf
@@ -4,7 +4,7 @@ module "vpc" {
     aws = aws.no-default-tags
   }
 
-  source = "git@github.com:hmrc/terraform-aws-vpc.git?ref=v3.6.0"
+  source = "github.com/hmrc/terraform-aws-vpc?ref=v3.6.0"
 
   name = var.name_prefix
 

--- a/modules/networking/vpc.tf
+++ b/modules/networking/vpc.tf
@@ -5,7 +5,6 @@ module "vpc" {
   }
 
   source  = "git@github.com:hmrc/terraform-aws-vpc.git"
-  version = "3.6.0"
 
   name = var.name_prefix
 


### PR DESCRIPTION
Since Terraform modules can't be pinned to a specific commit hash, there's a potential security risk in having someone change the code a version points to. To mitigate that we're vendor-ing our dependencies by maintaining forks and pointing at those in Terraform instead.

```terraform
$ make plan

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # module.github_scanner.module.common.aws_codepipeline_webhook.default has been changed
  ~ resource "aws_codepipeline_webhook" "default" {
        id              = "arn:aws:codepipeline:eu-west-2:987972305662:webhook:github-scanner-source-platsec-scanning-tools"
        name            = "github-scanner-source-platsec-scanning-tools"
        tags            = {}
      ~ tags_all        = {
          - "Name"      = "mdtp-live-platsec-ci" -> null
          - "Namespace" = "mdtp" -> null
          - "Stage"     = "live" -> null
        }
        # (5 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }
  # module.networking[0].aws_vpc_endpoint.s3 has been changed
  ~ resource "aws_vpc_endpoint" "s3" {
      ~ cidr_blocks           = [
            "52.95.150.0/24",
          + "52.95.191.0/24",
            "52.95.142.0/23",
            # (1 unchanged element hidden)
            "3.5.244.0/22",
          + "52.219.219.0/24",
            "52.95.144.0/24",
            # (2 unchanged elements hidden)
        ]
        id                    = "vpce-0911ff34159ebdbf6"
        tags                  = {
            "Name" = "mdtp-live-platsec-ci-s3"
        }
        # (16 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.github_scanner.module.common.aws_codepipeline_webhook.default will be updated in-place
  ~ resource "aws_codepipeline_webhook" "default" {
        id              = "arn:aws:codepipeline:eu-west-2:987972305662:webhook:github-scanner-source-platsec-scanning-tools"
        name            = "github-scanner-source-platsec-scanning-tools"
        tags            = {}
      ~ tags_all        = {
          + "Name"      = "mdtp-live-platsec-ci"
          + "Namespace" = "mdtp"
          + "Stage"     = "live"
        }
        # (5 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.


```