### PR TITLE
PSEC-1650 match new lambda name

### DIFF
--- a/pipelines.tf
+++ b/pipelines.tf
@@ -67,7 +67,7 @@ module "cloudtrail_monitoring" {
   pipeline_name = "cloudtrail-monitoring"
   src_repo      = "platsec-cloudtrail-monitoring"
 
-  lambda_function_name = "platsec_cloudtrail_monitoring"
+  lambda_function_name = "orgtrail-monitoring"
   ecr_url              = module.cloudtrail_monitoring_repository.url
   ecr_arn              = module.cloudtrail_monitoring_repository.arn
 

--- a/pipelines.tf
+++ b/pipelines.tf
@@ -67,7 +67,7 @@ module "cloudtrail_monitoring" {
   pipeline_name = "cloudtrail-monitoring"
   src_repo      = "platsec-cloudtrail-monitoring"
 
-  lambda_function_name = "orgtrail-monitoring"
+  lambda_function_name = "platsec-cloudtrail-monitoring"
   ecr_url              = module.cloudtrail_monitoring_repository.url
   ecr_arn              = module.cloudtrail_monitoring_repository.arn
 


### PR DESCRIPTION
## What
- Use new lambda function name for deployment

## Why
- This lambda has suitable ECR compatibility
- Deployment is already broken