### PR TITLE
PSEC-1973 introducing parameter to control the deployment package nam…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ deployment as:
 
 To be able to use this pipeline you need to supply `buildspec.yml` in the root
 of your repo which will be used by CI to build the artefact. The artefact needs
-to be saved in the root of the repo as `lambda.zip`.
+to be saved in the root of the repo, which, by default has to be, `lambda.zip`.
+However, this can be overwritten by specifying `lambda_deployment_package_name`
+environment variable. If the environment variable is not specified `lambda.zip`
+will be used.
 
 For example this buildspec will use `Makefile` to run all tests, then build
 lambda package and finally save it as artifact `lambda.zip`.

--- a/modules/lambda_zip_pipeline/build.tf
+++ b/modules/lambda_zip_pipeline/build.tf
@@ -34,10 +34,11 @@ module "zip_upload_artifactory_step" {
 module "zip-deployment-step-development" {
   source = "../zip_deployment_step"
 
-  lambda_arn            = "arn:aws:lambda:${var.target_region}:${var.accounts.development.id}:function:${var.lambda_function_name}"
-  step_name             = "${module.common.pipeline_name}-development"
-  build_core_policy_arn = module.common.policy_build_core_arn
-  deployment_role_arn   = var.accounts.development.role_arns["lambda-deploy"]
+  lambda_arn                     = "arn:aws:lambda:${var.target_region}:${var.accounts.development.id}:function:${var.lambda_function_name}"
+  lambda_deployment_package_name = var.lambda_deployment_package_name
+  step_name                      = "${module.common.pipeline_name}-development"
+  build_core_policy_arn          = module.common.policy_build_core_arn
+  deployment_role_arn            = var.accounts.development.role_arns["lambda-deploy"]
 
   vpc_config               = var.vpc_config
   agent_security_group_ids = [var.ci_agent_to_endpoints_sg_id]
@@ -46,10 +47,11 @@ module "zip-deployment-step-development" {
 module "zip-deployment-step-production" {
   source = "../zip_deployment_step"
 
-  lambda_arn            = "arn:aws:lambda:${var.target_region}:${var.accounts.production.id}:function:${var.lambda_function_name}"
-  step_name             = "${module.common.pipeline_name}-production"
-  build_core_policy_arn = module.common.policy_build_core_arn
-  deployment_role_arn   = var.accounts.production.role_arns["lambda-deploy"]
+  lambda_arn                     = "arn:aws:lambda:${var.target_region}:${var.accounts.production.id}:function:${var.lambda_function_name}"
+  step_name                      = "${module.common.pipeline_name}-production"
+  lambda_deployment_package_name = var.lambda_deployment_package_name
+  build_core_policy_arn          = module.common.policy_build_core_arn
+  deployment_role_arn            = var.accounts.production.role_arns["lambda-deploy"]
 
   vpc_config               = var.vpc_config
   agent_security_group_ids = [var.ci_agent_to_endpoints_sg_id]

--- a/modules/lambda_zip_pipeline/variables.tf
+++ b/modules/lambda_zip_pipeline/variables.tf
@@ -84,3 +84,8 @@ variable "admin_role" {
   description = "The role for bucket policy admin"
   type        = string
 }
+
+variable "lambda_deployment_package_name" {
+  type    = string
+  default = "lambda.zip"
+}

--- a/modules/zip_deployment_step/assets/buildspec-deploy.yaml
+++ b/modules/zip_deployment_step/assets/buildspec-deploy.yaml
@@ -21,6 +21,6 @@ phases:
       - |
         aws lambda update-function-code \
           --function-name ${LAMBDA_ARN} \
-          --zip-file fileb://lambda.zip \
+          --zip-file fileb://${LAMBDA_DEPLOYMENT_PACKAGE_NAME} \
           --publish \
           --profile zip-deployment

--- a/modules/zip_deployment_step/codebuild.tf
+++ b/modules/zip_deployment_step/codebuild.tf
@@ -23,6 +23,11 @@ resource "aws_codebuild_project" "deploy" {
       name  = "LAMBDA_ARN"
       value = var.lambda_arn
     }
+
+    environment_variable {
+      name  = "LAMBDA_DEPLOYMENT_PACKAGE_NAME"
+      value = var.lambda_deployment_package_name
+    }
   }
 
   logs_config {

--- a/modules/zip_deployment_step/variables.tf
+++ b/modules/zip_deployment_step/variables.tf
@@ -37,3 +37,8 @@ variable "lambda_arn" {
     error_message = "Arn must be given and should start with 'arn:aws:lambda:'."
   }
 }
+
+variable "lambda_deployment_package_name" {
+  type    = string
+  default = "lambda.zip"
+}

--- a/pipelines.tf
+++ b/pipelines.tf
@@ -169,15 +169,15 @@ module "vault_policy_applier_corretto" {
   src_repo      = "vault-policy-applier"
   github_token  = data.aws_secretsmanager_secret_version.github_token.secret_string
 
-  lambda_function_name = "policy-applier-corretto"
-
-  accounts                    = local.accounts
-  vpc_config                  = local.vpc_config
-  ci_agent_to_internet_sg_id  = local.ci_agent_to_internet_sg_id
-  ci_agent_to_endpoints_sg_id = local.ci_agent_to_endpoints_sg_id
-  sns_topic_arn               = module.ci_alerts_for_production.sns_topic_arn
-  access_log_bucket_id        = local.access_log_bucket_id
-  admin_role                  = local.tf_admin_role
+  lambda_function_name           = "policy-applier-corretto"
+  lambda_deployment_package_name = "vault-policy-applier-2-SNAPSHOT.jar"
+  accounts                       = local.accounts
+  vpc_config                     = local.vpc_config
+  ci_agent_to_internet_sg_id     = local.ci_agent_to_internet_sg_id
+  ci_agent_to_endpoints_sg_id    = local.ci_agent_to_endpoints_sg_id
+  sns_topic_arn                  = module.ci_alerts_for_production.sns_topic_arn
+  access_log_bucket_id           = local.access_log_bucket_id
+  admin_role                     = local.tf_admin_role
 }
 
 module "security_reports_frontend" {


### PR DESCRIPTION
This pr is to allow different package name for lambda_zip_pipeline only. The pr allows for specifying a different package name than lambda.zip, which is useful if a .jar file needs to be specified for instance.

The new `lambda_deployment_package_name` variable is introduced to achieve this. If it is not specified  the default package name of lambda.zip is used.

There are no changes to lambda_docker_pipeline