### PR TITLE
PSEC-2221-latest-ecr-image

### DIFF
--- a/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
+++ b/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
@@ -15,3 +15,4 @@ phases:
       - docker load -i docker.tar
       - docker tag container-release:local "${ECR_URL}:${IMAGE_TAG}"
       - docker push "${ECR_URL}:${IMAGE_TAG}"
+      - docker push "${ECR_URL}:latest


### PR DESCRIPTION
Step to push 'latest' tag of the most recently built image container to ECR added