### PR TITLE
PSEC-2221-revert-latest-image-tag-change

### DIFF
--- a/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
+++ b/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
@@ -15,5 +15,3 @@ phases:
       - docker load -i docker.tar
       - docker tag container-release:local "${ECR_URL}:${IMAGE_TAG}"
       - docker push "${ECR_URL}:${IMAGE_TAG}"
-      - docker tag container-release:local "${ECR_URL}:latest"
-      - docker push "${ECR_URL}:latest"


### PR DESCRIPTION
revert push of `latest` image tag as image_tag_mutability property of the repository is set to `IMMUTABLE`