### PR TITLE
PSEC-1793-testing-terragrunt-migration-of-platsec-terraform

### DIFF
--- a/modules/pull_request_builder/buildspecs/platsec_terraform_plan.yaml
+++ b/modules/pull_request_builder/buildspecs/platsec_terraform_plan.yaml
@@ -7,6 +7,10 @@ phases:
   build:
     commands:
       - make all-checks
-      - scripts/run.sh validate-main development
-      - scripts/run.sh plan development
-      - scripts/run.sh plan production
+      - time scripts/run.sh validate-main development # why validate only development?
+      - time scripts/run.sh plan development
+      - time scripts/run.sh plan production
+      - echo -e "\n\n\n\n###### Testing TERRAGRUNT [psec-1793]\n\n"
+      - time make tg-validate-development
+      - time make tg-plan-development
+      - time make tg-plan-production


### PR DESCRIPTION
Updated platsec-terraform pull request builder job buildspec to test terragrunt make targets

Why?
This helps achieve a couple of things:
1. tests 'plan' runs successfully on each environment 
2. allows us to confirm the outputs of 'terraform plan' and the new 'terragrunt plan' are the same, and compare the time it takes to run each command

Because we are literally running 'plan' twice, we expect the build time to increase in the meantime