### PR TITLE
PSEC-2258-image-tag-latest

### DIFF
--- a/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
+++ b/modules/upload_to_ci_ecr_step/assets/upload-to-ecr.yaml
@@ -17,6 +17,6 @@ phases:
       - docker tag container-release:local "${ECR_URL}:${IMAGE_TAG}"
       - docker push "${ECR_URL}:${IMAGE_TAG}"
       - | # create a "latest" imageTag if it does not exist
-        aws ecr describe-images --repository-name "${ECR_URL##*/} --image-ids imageTag=latest \
+        aws ecr describe-images --repository-name "${ECR_URL##*/}" --image-ids imageTag=latest \
           || docker tag container-release:local "${ECR_URL}:latest" \
           && docker push "${ECR_URL}:latest"


### PR DESCRIPTION
Ensure there's a 'latest' image tag in ECR repos

Why?
TF config in platsec-terraform for our lambdas reference '<imageRepo>:latest' to 
allow initial bootstrapping of the lambda. However, this fails because there is no
supporting config in platsec-ci-terraform to ensure that a 'latest' image tag is 
created.
This change aims to resolve that issue.