### PR TITLE
PSEC-2388 split roles read, write and list for cf and tf buckets + add RoleProwlerScanner to cf template

### DIFF
--- a/bootstrap/s3.tf
+++ b/bootstrap/s3.tf
@@ -1,18 +1,28 @@
 data "aws_caller_identity" "current" {}
 
 locals {
-  tf_read_roles          = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleProwlerScanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer"]
-  tf_list_roles          = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleProwlerScanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer"]
-  tf_metadata_read_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleProwlerScanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer"]
-  tf_write_roles         = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier"]
-  tf_admin_roles         = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier"]
 
-  cf_templates_all_roles = [
+  tf_readers = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleProwlerScanner",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer"
+  ]
+  tf_writers     = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier"]
+  tf_admin_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier"]
+
+
+  cf_templates_readers = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleProwlerScanner",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleChangeSetCreator",
     "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleIAMAdministrator",
+  ]
+
+  cf_templates_writers = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier",
   ]
 
   tf_state_bucket_name    = "platsec-ci20210713082841419000000002"
@@ -23,7 +33,7 @@ module "access_logs" {
   source      = "../modules/access_logs_bucket"
   bucket_name = local.access_logs_bucket_name
   admin_roles = local.tf_admin_roles
-  read_roles  = local.tf_read_roles
+  read_roles  = local.tf_readers
 }
 
 module "state_bucket" {
@@ -32,10 +42,10 @@ module "state_bucket" {
   bucket_name   = local.tf_state_bucket_name
   force_destroy = false
 
-  list_roles          = local.tf_list_roles
-  read_roles          = local.tf_read_roles
-  metadata_read_roles = local.tf_metadata_read_roles
-  write_roles         = local.tf_write_roles
+  list_roles          = local.tf_readers
+  read_roles          = local.tf_readers
+  metadata_read_roles = local.tf_readers
+  write_roles         = local.tf_writers
   admin_roles         = local.tf_admin_roles
 
   data_expiry      = "forever-config-only"
@@ -50,10 +60,10 @@ module "cf_templates_bucket" {
   bucket_name   = "cf-templates-1a94pgui3v5ft-eu-west-2"
   force_destroy = false
 
-  list_roles          = local.cf_templates_all_roles
-  read_roles          = local.cf_templates_all_roles
-  write_roles         = local.cf_templates_all_roles
-  metadata_read_roles = local.cf_templates_all_roles
+  list_roles          = local.cf_templates_readers
+  read_roles          = local.cf_templates_readers
+  metadata_read_roles = local.cf_templates_readers
+  write_roles         = local.cf_templates_writers
   admin_roles         = local.tf_admin_roles
 
   data_expiry      = "90-days"


### PR DESCRIPTION
- Separated read-only, write-only  into their own individual variables.
- Allow RoleProwlerScanner to read and list CF template bucket 
https://jira.tools.tax.service.gov.uk/browse/PSEC-2388