### PR TITLE
PSEC-2455 adjust ECR lifecycle policy to only keep last 10 images

### DIFF
--- a/modules/ecr_repository/main.tf
+++ b/modules/ecr_repository/main.tf
@@ -12,12 +12,12 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_rule" {
     "rules": [
         {
             "rulePriority": 1,
-            "description": "Keep last 100 images",
+            "description": "Keep last 10 images",
             "selection": {
                 "tagStatus": "tagged",
                 "tagPrefixList": ["v"],
                 "countType": "imageCountMoreThan",
-                "countNumber": 100
+                "countNumber": 10
             },
             "action": {
                 "type": "expire"


### PR DESCRIPTION
This change includes reducing the number of ECR images retained from 100 to 10.
Jira ticket : https://jira.tools.tax.service.gov.uk/browse/PSEC-2455