### PR TITLE
PSEC-2455 Update ECR lifecycle policy to retain only the last 10 tagged images

### DIFF
--- a/modules/ecr_repository/main.tf
+++ b/modules/ecr_repository/main.tf
@@ -15,7 +15,7 @@ resource "aws_ecr_lifecycle_policy" "ecr_lifecycle_rule" {
             "description": "Keep last 10 images",
             "selection": {
                 "tagStatus": "tagged",
-                "tagPrefixList": ["v"],
+                "tagPatternList": ["*"],
                 "countType": "imageCountMoreThan",
                 "countNumber": 10
             },


### PR DESCRIPTION
This change includes removing the the "tagPrefixList": ["v"] and adding "tagPatternList": ["*"] to allow us to retain only the last 10 tagged images

Jira ticket:
https://jira.tools.tax.service.gov.uk/browse/PSEC-2455