### PR TITLE
PSEC-2563: Restrict the CIDR Block of the Security Groups

### DIFF
--- a/modules/networking-new/ci_security_group.tf
+++ b/modules/networking-new/ci_security_group.tf
@@ -5,7 +5,7 @@ resource "aws_security_group" "aws_interface_endpoints" {
     from_port   = 0
     protocol    = "-1"
     to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [module.vpc.vpc_cidr_block]
   }
 
   tags = var.tags


### PR DESCRIPTION
Describe your changes
Restrict the overly permissive security group - `mdtp-platsec-ci-terraform-aws-interface-endpoints`

Issue ticket number and link
[PSEC-2563](https://jira.tools.tax.service.gov.uk/browse/PSEC-2563)