### PR TITLE
PSEC-2577-cloudtrail-events-monitoring-pipeline

### DIFF
--- a/live/ecr_repositories.tf
+++ b/live/ecr_repositories.tf
@@ -65,6 +65,18 @@ module "cloudtrail_monitoring_repository" {
 }
 
 
+module "cloudtrail_events_monitor_repository" {
+  source = "../modules//ecr_repository"
+
+  repository_name            = "cloudtrail-events-monitor"
+  allow_read_account_id_list = local.all_platsec_account_ids
+
+  tags = {
+    service = "cloudtrail-events-monitor"
+  }
+}
+
+
 module "compliance_alerting_repository" {
   source = "../modules//ecr_repository"
 

--- a/live/pipelines.tf
+++ b/live/pipelines.tf
@@ -97,6 +97,30 @@ module "cloudtrail_monitoring" {
   }
 }
 
+module "cloudtrail_events_monitor" {
+  source = "../modules//lambda_docker_pipeline"
+
+  pipeline_name = "cloudtrail-events-monitor"
+  src_repo      = "platsec-cloudtrail-monitoring"
+
+  lambda_function_name = "cloudtrail-events-monitor-lambda"
+  ecr_url              = module.cloudtrail_events_monitor_repository.url
+  ecr_arn              = module.cloudtrail_events_monitor_repository.arn
+
+  accounts                 = local.accounts
+  codeconnection_arn       = data.aws_codestarconnections_connection.this.arn
+  github_token             = data.aws_secretsmanager_secret_version.github_token.secret_string
+  sns_topic_arn            = local.ci_alerts_sns_topic_arn
+  access_log_bucket_id     = local.access_log_bucket_id
+  admin_roles              = local.tf_admin_roles
+  vpc_config               = local.vpc_config
+  agent_security_group_ids = local.agent_security_group_ids
+
+  tags = {
+    service = "cloudtrail-events-monitor"
+  }
+}
+
 module "github_scanner" {
   source = "../modules//lambda_docker_pipeline"
 

--- a/modules/lambda_docker_pipeline/pipeline.tf
+++ b/modules/lambda_docker_pipeline/pipeline.tf
@@ -89,6 +89,14 @@ resource "aws_codepipeline" "codepipeline" {
             name  = "IMAGE_TAG"
             value = module.common.build_id
             type  = "PLAINTEXT"
+          },
+          # PSEC-2577: temp env var to support cloudtrail-events-monitoring
+          #            and platsec-cloudtrail-monitoring pipelines.
+          #            To be removed post-PSEC-2577
+          {
+            name  = "PIPELINE_NAME"
+            value = module.common.pipeline_name
+            type  = "PLAINTEXT"
           }
         ])
       }


### PR DESCRIPTION
- Creates cloudtrail-events-monitor lambda pipeline
- adds extra (but temporary) environment variable PIPELINE_NAME to Upload_Image step. The env var is to enable completion of PSEC-2577