### PR TITLE
PSEC-2565-kms-key-policy-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ plan: plan-ci plan-live
 .PHONY: plan-%
 plan-ci: export AWS_PROFILE := platsec-ci-RoleTerraformPlanner
 plan-live: export AWS_PROFILE := platsec-ci-RoleTerraformPlanner
-plan-%: fmt-check
+plan-%: fmt
 	@cd ./$*
 	@rm -f .terraform/terraform.tfstate
 	@$(AWS_PROFILE_CMD) $(TF) init
@@ -99,7 +99,7 @@ clean:
 
 .PHONY: plan-bootstrap
 plan-bootstrap: export AWS_PROFILE := platsec-ci-RoleTerraformPlanner
-plan-bootstrap: fmt-check
+plan-bootstrap: fmt
 	@cd ./bootstrap
 	@rm -f .terraform/terraform.tfstate
 	@$(AWS_PROFILE_CMD) $(TF) init

--- a/modules/pipeline_common/iam.tf
+++ b/modules/pipeline_common/iam.tf
@@ -1,3 +1,6 @@
+locals {
+  pipeline_role_name = substr(local.pipeline_name, 0, 32)
+}
 
 data "aws_caller_identity" "current" {}
 
@@ -86,7 +89,7 @@ data "aws_iam_policy_document" "codepipeline_policy" {
 }
 
 resource "aws_iam_policy" "codepipeline_policy" {
-  name_prefix = substr(local.pipeline_name, 0, 32)
+  name_prefix = local.pipeline_role_name
   description = "${local.pipeline_name} CodePipeline"
   policy      = data.aws_iam_policy_document.codepipeline_policy.json
 
@@ -100,7 +103,7 @@ resource "aws_iam_policy" "codepipeline_policy" {
 }
 
 resource "aws_iam_role" "codepipeline_role" {
-  name_prefix         = substr(local.pipeline_name, 0, 32)
+  name_prefix         = local.pipeline_role_name
   description         = "${local.pipeline_name} CodePipeline"
   assume_role_policy  = data.aws_iam_policy_document.codepipeline_assume_role.json
   managed_policy_arns = [aws_iam_policy.codepipeline_policy.arn]
@@ -202,7 +205,7 @@ data "aws_iam_policy_document" "store_artifacts" {
 }
 
 resource "aws_iam_policy" "build_core" {
-  name_prefix = substr(local.pipeline_name, 0, 32)
+  name_prefix = local.pipeline_role_name
   description = "${local.pipeline_name} build"
   policy      = data.aws_iam_policy_document.build_core.json
 
@@ -216,7 +219,7 @@ resource "aws_iam_policy" "build_core" {
 }
 
 resource "aws_iam_policy" "store_artifacts" {
-  name_prefix = substr(local.pipeline_name, 0, 32)
+  name_prefix = local.pipeline_role_name
   description = "${local.pipeline_name} store artefacts"
   policy      = data.aws_iam_policy_document.store_artifacts.json
 

--- a/modules/pipeline_common/s3.tf
+++ b/modules/pipeline_common/s3.tf
@@ -1,11 +1,23 @@
 locals {
   bucket_name = "ci-${substr(local.pipeline_name, 0, 32)}"
+  readers = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformPlanner",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.pipeline_role_name}*",
+  ]
+  writers = [
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleTerraformApplier",
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleSecurityEngineer",
+  ]
+  admins = concat(var.admin_roles, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleKmsAdministrator"])
 }
 
 module "kms_key_policy_document" {
   source = "../kms_key_policy"
 
-  admin_roles = concat(var.admin_roles, ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/RoleKmsAdministrator"])
+  read_roles  = local.readers
+  write_roles = local.writers
+  admin_roles = local.admins
 }
 
 module "codepipeline_bucket" {

--- a/modules/pull_request_builder/iam.tf
+++ b/modules/pull_request_builder/iam.tf
@@ -1,6 +1,7 @@
 locals {
   default_policy_arns = [aws_iam_policy.build.arn, aws_iam_policy.build_core.arn]
   managed_policy_arns = length(var.project_assume_roles) == 0 ? local.default_policy_arns : concat(local.default_policy_arns, [aws_iam_policy.project_assume_roles[0].arn])
+  project_role_name   = substr(var.project_name, 0, 32)
 }
 
 data "aws_caller_identity" "current" {}
@@ -27,7 +28,7 @@ data "aws_iam_policy_document" "codebuild_assume_role" {
 }
 
 resource "aws_iam_role" "build" {
-  name_prefix         = substr(var.project_name, 0, 32)
+  name_prefix         = local.project_role_name
   description         = "${var.project_name} build"
   assume_role_policy  = data.aws_iam_policy_document.codebuild_assume_role.json
   managed_policy_arns = local.managed_policy_arns
@@ -76,7 +77,7 @@ data "aws_iam_policy_document" "build" {
 }
 
 resource "aws_iam_policy" "build" {
-  name_prefix = substr(var.project_name, 0, 32)
+  name_prefix = local.project_role_name
   description = "${var.project_name} store artefacts"
 
   policy = data.aws_iam_policy_document.build.json
@@ -102,7 +103,7 @@ data "aws_iam_policy_document" "project_assume_roles" {
 
 resource "aws_iam_policy" "project_assume_roles" {
   count       = length(var.project_assume_roles) == 0 ? 0 : 1
-  name_prefix = substr(var.project_name, 0, 32)
+  name_prefix = local.project_role_name
   policy      = data.aws_iam_policy_document.project_assume_roles[0].json
   description = "${var.project_name} codebuild project assume roles"
   tags        = var.tags
@@ -198,7 +199,7 @@ data "aws_iam_policy_document" "build_core" {
 }
 
 resource "aws_iam_policy" "build_core" {
-  name_prefix = substr(var.project_name, 0, 32)
+  name_prefix = local.project_role_name
   description = "${var.project_name} build"
   policy      = data.aws_iam_policy_document.build_core.json
 


### PR DESCRIPTION
This fix ensures that kms key policy allows codebuild project and codepipeline roles access to their kms keys. 

Currently, a local TFApply is required to fix this missing permission. This change ensures that the fix is in code.