### PR TITLE
PSEC-3207:  ECR repo and push permission for the new lambda

### DIFF
--- a/live/ecr_repositories.tf
+++ b/live/ecr_repositories.tf
@@ -76,6 +76,24 @@ module "cloudtrail_events_monitor_repository" {
   }
 }
 
+# Adopts the ECR repo created manually while bootstrapping the vpc-flow-logs-splunk-lambda deploy.
+# Will remove this block after the first successful apply.
+import {
+  to = module.vpc_flow_logs_splunk_lambda_repository.aws_ecr_repository.ecr_repository
+  id = "vpc-flow-logs-splunk-lambda"
+}
+
+module "vpc_flow_logs_splunk_lambda_repository" {
+  source = "../modules//ecr_repository"
+
+  repository_name            = "vpc-flow-logs-splunk-lambda"
+  allow_read_account_id_list = local.all_platsec_account_ids
+
+  tags = {
+    service = "vpc-flow-logs-splunk-lambda"
+  }
+}
+
 
 module "compliance_alerting_repository" {
   source = "../modules//ecr_repository"

--- a/live/ecr_repositories.tf
+++ b/live/ecr_repositories.tf
@@ -76,13 +76,6 @@ module "cloudtrail_events_monitor_repository" {
   }
 }
 
-# Adopts the ECR repo created manually while bootstrapping the vpc-flow-logs-splunk-lambda deploy.
-# Will remove this block after the first successful apply.
-import {
-  to = module.vpc_flow_logs_splunk_lambda_repository.aws_ecr_repository.ecr_repository
-  id = "vpc-flow-logs-splunk-lambda"
-}
-
 module "vpc_flow_logs_splunk_lambda_repository" {
   source = "../modules//ecr_repository"
 

--- a/live/pipelines.tf
+++ b/live/pipelines.tf
@@ -412,6 +412,10 @@ module "central_account_terraform_pipeline" {
     },
   ]
 
+  ecr_push_repository_arns = [
+    module.vpc_flow_logs_splunk_lambda_repository.arn,
+  ]
+
   tags = {
     service = "central_account_terraform_pipeline"
   }

--- a/modules/central_audit_terraform_pipeline/build.tf
+++ b/modules/central_audit_terraform_pipeline/build.tf
@@ -1,5 +1,11 @@
 locals {
   step_assume_roles = merge(var.step_assume_roles...)
+
+  # Pre-computed string ARN — using aws_iam_policy.ecr_push[0].arn here would leave the
+  # element unknown at plan time and break toset() in the terraform_step module's for_each.
+  ecr_push_policy_arns = length(var.ecr_push_repository_arns) == 0 ? [] : [
+    "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.pipeline_name}-ecr-push"
+  ]
 }
 
 
@@ -14,7 +20,7 @@ module "apply_step" {
   s3_bucket_arn = module.common.bucket_arn
   policy_arns = concat(
     [module.common.policy_build_core_arn, aws_iam_policy.secretsmanager.arn],
-    length(var.ecr_push_repository_arns) == 0 ? [] : [aws_iam_policy.ecr_push[0].arn],
+    local.ecr_push_policy_arns,
   )
   step_assume_roles   = each.value
   build_spec_contents = templatefile("${path.module}/buildspecs/apply.yaml.tpl", { target = each.key })
@@ -23,4 +29,6 @@ module "apply_step" {
   agent_security_group_ids = values(var.agent_security_group_ids)
 
   tags = var.tags
+
+  depends_on = [aws_iam_policy.ecr_push]
 }

--- a/modules/central_audit_terraform_pipeline/build.tf
+++ b/modules/central_audit_terraform_pipeline/build.tf
@@ -11,8 +11,11 @@ module "apply_step" {
   step_name          = "${module.common.pipeline_name}-apply-${each.key}"
   timeout_in_minutes = var.test_timeout_in_minutes
 
-  s3_bucket_arn       = module.common.bucket_arn
-  policy_arns         = [module.common.policy_build_core_arn, aws_iam_policy.secretsmanager.arn]
+  s3_bucket_arn = module.common.bucket_arn
+  policy_arns = concat(
+    [module.common.policy_build_core_arn, aws_iam_policy.secretsmanager.arn],
+    length(var.ecr_push_repository_arns) == 0 ? [] : [aws_iam_policy.ecr_push[0].arn],
+  )
   step_assume_roles   = each.value
   build_spec_contents = templatefile("${path.module}/buildspecs/apply.yaml.tpl", { target = each.key })
 

--- a/modules/central_audit_terraform_pipeline/iam.tf
+++ b/modules/central_audit_terraform_pipeline/iam.tf
@@ -30,3 +30,41 @@ resource "aws_iam_policy" "secretsmanager" {
     Pipeline = var.pipeline_name
   }, var.tags)
 }
+
+data "aws_iam_policy_document" "ecr_push" {
+  count = length(var.ecr_push_repository_arns) == 0 ? 0 : 1
+
+  statement {
+    sid       = "GetAuthorizationToken"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "PushImages"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+    ]
+    resources = var.ecr_push_repository_arns
+  }
+}
+
+resource "aws_iam_policy" "ecr_push" {
+  count = length(var.ecr_push_repository_arns) == 0 ? 0 : 1
+
+  name_prefix = substr(var.pipeline_name, 0, 32)
+  description = "${var.pipeline_name} push images to ECR"
+  policy      = data.aws_iam_policy_document.ecr_push[0].json
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge({
+    Pipeline = var.pipeline_name
+  }, var.tags)
+}

--- a/modules/central_audit_terraform_pipeline/iam.tf
+++ b/modules/central_audit_terraform_pipeline/iam.tf
@@ -3,6 +3,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}
 
+data "aws_partition" "current" {}
+
 data "aws_iam_policy_document" "secretsmanager" {
   statement {
     actions = [
@@ -56,13 +58,10 @@ data "aws_iam_policy_document" "ecr_push" {
 resource "aws_iam_policy" "ecr_push" {
   count = length(var.ecr_push_repository_arns) == 0 ? 0 : 1
 
-  name_prefix = substr(var.pipeline_name, 0, 32)
+  # Static name so the ARN is known at plan time (see ecr_push_policy_arns local in build.tf).
+  name        = "${var.pipeline_name}-ecr-push"
   description = "${var.pipeline_name} push images to ECR"
   policy      = data.aws_iam_policy_document.ecr_push[0].json
-
-  lifecycle {
-    create_before_destroy = true
-  }
 
   tags = merge({
     Pipeline = var.pipeline_name

--- a/modules/central_audit_terraform_pipeline/variables.tf
+++ b/modules/central_audit_terraform_pipeline/variables.tf
@@ -70,3 +70,9 @@ variable "tags" {
   description = "A map of key, value pairs to be added to resources as tags"
   default     = {}
 }
+
+variable "ecr_push_repository_arns" {
+  type        = list(string)
+  description = "ECR repository ARNs the apply step is allowed to push images to"
+  default     = []
+}


### PR DESCRIPTION
The PR makes the following changes:

- New terraform-managed ECR repo for the lambda, using the shared repo module
- Central-audit-terraform pipeline given permission to push to it via a new optional input on the pipeline module